### PR TITLE
Resurrect lost gtk doc xml file

### DIFF
--- a/docs/polkit-gtk-mate-1-docs.xml
+++ b/docs/polkit-gtk-mate-1-docs.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+               "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!ENTITY version SYSTEM "version.xml">
+]>
+<book id="index" xmlns:xi="http://www.w3.org/2003/XInclude">
+  <bookinfo>
+    <title>PolicyKit-GTK+ Reference Manual</title>
+    <releaseinfo>Version &version;</releaseinfo>
+    <authorgroup>
+      <author>
+        <firstname>David</firstname>
+        <surname>Zeuthen</surname>
+        <affiliation>
+          <address>
+            <email>davidz@redhat.com</email>
+          </address>
+        </affiliation>
+      </author>
+    </authorgroup>
+
+    <copyright>
+      <year>2008-2009</year>
+      <holder>The PolicyKit Authors</holder>
+    </copyright>
+
+    <legalnotice id="polkit-legal-notice">
+      <para>
+        Permission is granted to copy, distribute and/or modify this
+        document under the terms of the <citetitle>GNU Free
+        Documentation License</citetitle>, Version 1.1 or any later
+        version published by the Free Software Foundation with no
+        Invariant Sections, no Front-Cover Texts, and no Back-Cover
+        Texts. You may obtain a copy of the <citetitle>GNU Free
+        Documentation License</citetitle> from the Free Software
+        Foundation by visiting <ulink type="http"
+        url="http://www.fsf.org">their Web site</ulink> or by writing
+        to:
+
+        <address>
+          The Free Software Foundation, Inc.,
+          <street>59 Temple Place</street> - Suite 330,
+          <city>Boston</city>, <state>MA</state> <postcode>02111-1307</postcode>,
+          <country>USA</country>
+        </address>
+      </para>
+
+      <para>
+        Many of the names used by companies to distinguish their
+        products and services are claimed as trademarks. Where those
+        names appear in any GNOME documentation, and those
+        trademarks are made aware to the members of the
+        GNOME Documentation Project, the names have been
+        printed in caps or initial caps.
+      </para>
+    </legalnotice>
+  </bookinfo>
+
+  <part id="ref-gtk-api">
+    <title>API Reference</title>
+    <xi:include href="xml/polkitlockbutton.xml"/>
+  </part>
+
+
+  <chapter id="polkit-gtk-hierarchy">
+    <title>Object Hierarchy</title>
+      <xi:include href="xml/tree_index.sgml"/>
+  </chapter>
+
+  <index id="polkit-gtk-index">
+    <title>Index</title>
+  </index>
+
+</book>


### PR DESCRIPTION
I could not find any commit that deleted it so it must have gone missing before it was imported here. Now gtk docs are build again :)
