### PR TITLE
don't lose focus when displaying password prompt dialog

### DIFF
--- a/src/polkitmateauthenticator.c
+++ b/src/polkitmateauthenticator.c
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <glib/gi18n.h>
+#include <gdk/gdkx.h>
 
 #include <polkit/polkit.h>
 #include <polkitagent/polkitagent.h>
@@ -304,7 +305,8 @@ session_request (PolkitAgentSession *session,
     }
 
   gtk_widget_show_all (GTK_WIDGET (authenticator->dialog));
-  gtk_window_present (GTK_WINDOW (authenticator->dialog));
+  gtk_window_present_with_time (GTK_WINDOW (authenticator->dialog),
+                                gdk_x11_get_server_time (gtk_widget_get_window (GTK_WIDGET (authenticator->dialog))));
   password = polkit_mate_authentication_dialog_run_until_response_for_prompt (POLKIT_MATE_AUTHENTICATION_DIALOG (authenticator->dialog),
                                                                                modified_request,
                                                                                echo_on,


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-polkit/issues/19
fixes https://github.com/mate-desktop/marco/issues/117

thanks to Jeffrey Knockel
(see https://bugzilla.gnome.org/676076 and https://bugs.launchpad.net/bugs/946171)

@flexiondotorg @NiceandGently @infirit 
Please test if it fixes the problem on your machines. Steps to reproduce are in:
- https://github.com/mate-desktop/marco/issues/117 (with test script)
- [this Mint forum post](http://forums.linuxmint.com/viewtopic.php?f=206&t=169460#p876215) (with either ```mate-users-admin``` or ```users-admin```)

I'll be testing it here with Marco, but would also like to gather test results with other WMs (e.g. xfwm4 or compiz). Some of these WMs don't trigger the issue at all, I'd just like to make sure there are no regressions with them.