### PR TITLE
Add support for application indicators

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ MATE_COMPILE_WARNINGS([maximum])
 GLIB_REQUIRED=2.36.0
 POLKIT_AGENT_REQUIRED=0.97
 POLKIT_GOBJECT_REQUIRED=0.97
+APPINDICATOR_REQUIRED=0.0.13
 
 AC_MSG_CHECKING([which gtk+ version to compile against])
 AC_ARG_WITH([gtk],
@@ -164,6 +165,29 @@ AC_ARG_ENABLE([accountsservice],
 	      [enable_accountsservice=yes])
 
 AM_CONDITIONAL([HAVE_ACCOUNTSSERVICE], [test "x$enable_accountsservice" = xyes])
+
+# Application indicator
+AC_ARG_ENABLE([appindicator],
+	      AS_HELP_STRING([--enable-appindicator[=@<:@no/auto/yes@:>@]],[Build support for application indicators]),
+	      [enable_appindicator=$enableval],
+	      [enable_appindicator="auto"])
+
+
+if test "x$enable_appindicator" = "xauto"; then
+	PKG_CHECK_EXISTS(appindicator-0.1 >= $APPINDICATOR_REQUIRED,
+			 [enable_appindicator="yes"],
+			 [enable_appindicator="no"])
+fi
+
+if test "x$enable_appindicator" = "xyes"; then
+	PKG_CHECK_MODULES(APPINDICATOR,
+			  [appindicator-0.1 >= $APPINDICATOR_REQUIRED],
+			  [AC_DEFINE(HAVE_APPINDICATOR, 1, [Have AppIndicator])])
+fi
+
+AM_CONDITIONAL(HAVE_APPINDICATOR, test "x$enable_appindicator" = "xyes")
+AC_SUBST(APPINDICATOR_CFLAGS)
+AC_SUBST(APPINDICATOR_LIBS)
 
 AC_ARG_ENABLE([examples],
               AC_HELP_STRING([--enable-examples], [Build the example programs]),,
@@ -241,6 +265,7 @@ echo "
 
         Gtk+ version:               ${GTK_API_VERSION}
         Accountsservice:            ${enable_accountsservice}
+        Application indciator:      ${enable_appindicator}
         Maintainer mode:            ${USE_MAINTAINER_MODE}
         Building api docs:          ${enable_gtk_doc}
         GObject Introspection:      ${enable_introspection}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,6 +33,7 @@ polkit_mate_authentication_agent_1_CFLAGS = 		\
 	$(GLIB_CFLAGS)					\
 	$(POLKIT_AGENT_CFLAGS)				\
 	$(POLKIT_GOBJECT_CFLAGS)			\
+	$(APPINDICATOR_CFLAGS)				\
 	$(WARN_CFLAGS)					\
 	$(AM_CFLAGS)
 
@@ -44,6 +45,7 @@ polkit_mate_authentication_agent_1_LDADD = 		\
 	$(GLIB_LIBS)					\
 	$(POLKIT_AGENT_LIBS)				\
 	$(POLKIT_GOBJECT_LIBS)				\
+	$(APPINDICATOR_LIBS)				\
 	$(INTLLIBS)
 
 EXTRA_DIST = \


### PR DESCRIPTION
This add the revoke icon as an indicator. I still get the (slightly different) status icon in the notification area. But I never got indicators working under gentoo so this needs a bit of testing under Ubuntu.