### PR TITLE
require GTK+ >= 3.14, drop GTK+2 code and --with-gtk build option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,35 +122,14 @@ MATE_COMPILE_WARNINGS([maximum])
 # ***************************
 
 GLIB_REQUIRED=2.36.0
+GTK_REQUIRED=3.14.0
 POLKIT_AGENT_REQUIRED=0.97
 POLKIT_GOBJECT_REQUIRED=0.97
 APPINDICATOR_REQUIRED=0.0.13
 
-AC_MSG_CHECKING([which gtk+ version to compile against])
-AC_ARG_WITH([gtk],
-  [AS_HELP_STRING([--with-gtk=2.0|3.0],[which gtk+ version to compile against (default: 2.0)])],
-  [case "$with_gtk" in
-     2.0|3.0) ;;
-     *) AC_MSG_ERROR([invalid gtk version specified]) ;;
-   esac],
-  [with_gtk=2.0])
-AC_MSG_RESULT([$with_gtk])
-
-case "$with_gtk" in
-  2.0) GTK_API_VERSION=2.0
-       GTK_REQUIRED=2.24.0
-       APPINDICATOR_API_VERSION=
-       ;;
-  3.0) GTK_API_VERSION=3.0
-       GTK_REQUIRED=3.0.0
-       APPINDICATOR_API_VERSION=3
-       ;;
-esac
-AC_SUBST(GTK_API_VERSION)
-
 PKG_CHECK_MODULES(GLIB, glib-2.0 >= $GLIB_REQUIRED gio-2.0 >= $GLIB_REQUIRED)
 
-PKG_CHECK_MODULES(GTK, gtk+-$GTK_API_VERSION >= $GTK_REQUIRED)
+PKG_CHECK_MODULES(GTK, gtk+-3.0 >= $GTK_REQUIRED)
 AC_SUBST(GTK_CFLAGS)
 AC_SUBST(GTK_LIBS)
 
@@ -169,7 +148,7 @@ AC_ARG_ENABLE([accountsservice],
 AM_CONDITIONAL([HAVE_ACCOUNTSSERVICE], [test "x$enable_accountsservice" = xyes])
 
 # Application indicator
-APPINDICATOR_PKG=appindicator$APPINDICATOR_API_VERSION-0.1
+APPINDICATOR_PKG=appindicator3-0.1
 
 AC_ARG_ENABLE([appindicator],
 	      AS_HELP_STRING([--enable-appindicator[=@<:@no/auto/yes@:>@]],[Build support for application indicators]),
@@ -267,7 +246,6 @@ echo "
         cflags:                     ${CFLAGS}
         cppflags:                   ${CPPFLAGS}
 
-        Gtk+ version:               ${GTK_API_VERSION}
         Accountsservice:            ${enable_accountsservice}
         Application indicator:      ${enable_appindicator}
         Maintainer mode:            ${USE_MAINTAINER_MODE}

--- a/polkitgtkmate/Makefile.am
+++ b/polkitgtkmate/Makefile.am
@@ -83,12 +83,12 @@ PolkitGtkMate-1.0.gir: libpolkit-gtk-mate-1.la $(G_IR_SCANNER) Makefile.am
 		--namespace PolkitGtkMate		\
 		--strip-prefix=Polkit			\
 		--nsversion=1.0				\
-		--include=Gtk-${GTK_API_VERSION}	\
+		--include=Gtk-3.0	\
 		--include=Polkit-1.0			\
 		--library=polkit-gtk-mate-1		\
 		--output $@				\
 		--pkg=polkit-gobject-1			\
-		--pkg=gtk+-${GTK_API_VERSION}		\
+		--pkg=gtk+-3.0		\
 		--pkg-export=polkit-mate-gtk-1		\
 		--c-include='polkitgtkmate/polkitgtkmate.h'	\
 		--libtool=$(top_builddir)/libtool	\

--- a/polkitgtkmate/example.c
+++ b/polkitgtkmate/example.c
@@ -115,11 +115,7 @@ int main(int argc, char* argv[])
 	window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 	gtk_window_set_resizable(GTK_WINDOW(window), TRUE);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
-#else
-	vbox = gtk_vbox_new(FALSE, 12);
-#endif
 	gtk_container_set_border_width(GTK_CONTAINER(window), 12);
 	gtk_container_add(GTK_CONTAINER(window), vbox);
 

--- a/src/polkitmateauthenticationdialog.c
+++ b/src/polkitmateauthenticationdialog.c
@@ -664,28 +664,16 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
   gtk_window_set_resizable (GTK_WINDOW (dialog), FALSE);
   gtk_window_set_icon_name (GTK_WINDOW (dialog), GTK_STOCK_DIALOG_AUTHENTICATION);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
-#else
-  hbox = gtk_hbox_new (FALSE, 12);
-#endif
   gtk_container_set_border_width (GTK_CONTAINER (hbox), 5);
   gtk_box_pack_start (GTK_BOX (content_area), hbox, TRUE, TRUE, 0);
 
   image = get_image (dialog);
-#if GTK_CHECK_VERSION (3, 0, 0)
   gtk_widget_set_halign (image, GTK_ALIGN_CENTER);
   gtk_widget_set_valign (image, GTK_ALIGN_START);
-#else
-  gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.0);
-#endif
   gtk_box_pack_start (GTK_BOX (hbox), image, FALSE, FALSE, 0);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
   main_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 10);
-#else
-  main_vbox = gtk_vbox_new (FALSE, 10);
-#endif
   gtk_box_pack_start (GTK_BOX (hbox), main_vbox, TRUE, TRUE, 0);
 
   /* main message */
@@ -700,9 +688,7 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
   gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
   gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
-#if GTK_CHECK_VERSION (3, 0, 0)
   gtk_label_set_max_width_chars (GTK_LABEL (label), 50);
-#endif
   gtk_box_pack_start (GTK_BOX (main_vbox), label, FALSE, FALSE, 0);
 
   /* secondary message */
@@ -735,9 +721,7 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
   gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
   gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
-#if GTK_CHECK_VERSION (3, 0, 0)
   gtk_label_set_max_width_chars (GTK_LABEL (label), 50);
-#endif
   gtk_box_pack_start (GTK_BOX (main_vbox), label, FALSE, FALSE, 0);
 
   /* user combobox */
@@ -756,11 +740,7 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
     }
 
   /* password entry */
-#if GTK_CHECK_VERSION (3, 0, 0)
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-#else
-  vbox = gtk_vbox_new (FALSE, 0);
-#endif
   gtk_box_pack_start (GTK_BOX (main_vbox), vbox, FALSE, FALSE, 0);
 
   table_alignment = gtk_alignment_new (0.0, 0.0, 1.0, 1.0);
@@ -793,11 +773,7 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
   gtk_expander_set_use_markup (GTK_EXPANDER (details_expander), TRUE);
   gtk_box_pack_start (GTK_BOX (content_area), details_expander, FALSE, FALSE, 0);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
   details_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 10);
-#else
-  details_vbox = gtk_vbox_new (FALSE, 10);
-#endif
   gtk_container_add (GTK_CONTAINER (details_expander), details_vbox);
 
   table_alignment = gtk_alignment_new (0.0, 0.0, 1.0, 1.0);


### PR DESCRIPTION
@flexiondotorg @clefebvre @raveit65 @posophe @XRevan86 @willysr @obache @NP-Hardass

And now we move mate-polkit to GTK+3:

- minimum GTK+ version is set to 3.14
- GTK+2 code and deprecated GTK+3 code are dropped
- ```--with-gtk``` build option is dropped as well
- build-deps on GTK+ and appindicator dev packages are changed (that's what you need to do in your distros)

For example, in Debian/Ubuntu build-deps are changed as follows:
```libappindicator-dev -> libappindicator3-dev```
```libgtk2.0-dev -> libgtk-3-dev```

