### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -286,12 +286,14 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# gnomepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for PolicyKit-gnome.
+# Copyright © 2008-2010 the PolicyKit-gnome authors.
+# This file is distributed under the same license as the PolicyKit-gnome package.
+# Piotr Drąg <piotrdrag@gmail.com>, 2008-2010.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2008.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Aviary.pl <gnomepl@aviary.pl>, 2008-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.