### PR TITLE
Fix reshow/hide icon with statusnotifier

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -174,6 +174,10 @@ update_temporary_authorization_icon_real (void)
           app_indicator_set_status (app_indicator,
                                     APP_INDICATOR_STATUS_ACTIVE);
         }
+      else
+        /*Reshow icon from existing appindicator */
+        app_indicator_set_status (app_indicator,
+				    APP_INDICATOR_STATUS_ACTIVE);
 
 #else
       if (status_icon == NULL)
@@ -198,10 +202,9 @@ update_temporary_authorization_icon_real (void)
 #ifdef HAVE_APPINDICATOR
       if (app_indicator != NULL)
         {
+          /* keep the app_indicator, hide the icon or it won't come back*/
           app_indicator_set_status (app_indicator,
 				    APP_INDICATOR_STATUS_PASSIVE);
-          g_object_unref (app_indicator);
-          app_indicator = NULL;
         }
 #else
       if (status_icon != NULL)


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/mate-polkit/issues/35 and requires https://github.com/mate-desktop/mate-panel/pull/669 in mate-panel to work. The mate-panel change hides this icon and only this icon when it is set passive. This change, by keeping the same app_indicator structure instead of nulling it out, and just resetting it active if it already exists stops the problem of the icon not coming back up if shown and hidden once, which is what happens with only the change in mate-panel.