### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([polkit-mate],[1.22.0],[http://www.mate-desktop.org/],[mate-polkit])
+AC_INIT([polkit-mate],[1.22.0],[https://mate-desktop.org/],[mate-polkit])
 
 AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip check-news])
 


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.