### PR TITLE
autoconf: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,13 @@ AC_SUBST(LT_CURRENT)
 AC_SUBST(LT_REVISION)
 AC_SUBST(LT_AGE)
 
+# *****
+# MATE
+# *****
+
+MATE_DEBUG_CHECK
+MATE_COMPILE_WARNINGS([maximum])
+
 AC_PROG_CC
 AC_HEADER_STDC
 
@@ -107,13 +114,6 @@ else
     AC_MSG_ERROR([--enable-gcov can only be used with gcc])
   fi
 fi
-
-# *****
-# MATE
-# *****
-
-MATE_DEBUG_CHECK
-MATE_COMPILE_WARNINGS([maximum])
 
 # ***************************
 # Check for required packages


### PR DESCRIPTION
`AX_CHECK_ENABLE_DEBUG` must go before `AC_PROG_CC`, otherwise it will overwrite make [variables](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html).

### Macros
- [mate-common.m4](https://github.com/mate-desktop/mate-common/blob/master/macros/mate-common.m4) : MATE_COMMON_INIT, MATE_DEBUG_CHECK, MATE_MAINTAINER_MODE_DEFINES
- [mate-compiler-flags.m4](https://github.com/mate-desktop/mate-common/blob/master/macros/mate-compiler-flags.m4) : MATE_COMPILE_WARNINGS([maximum])

### Test
```
$ ./autogen.sh --prefix=/usr &> run.log
$ grep "AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG" run.log
```
### Output before PR
```
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
configure.ac:115: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
```