### PR TITLE
Compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,40 +39,6 @@ LT_INIT
 
 if test "x$GCC" = "xyes"; then
   changequote(,)dnl
-  case " $CFLAGS " in
-  *[\ \	]-Wall[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wall" ;;
-  esac
-
-  case " $CFLAGS " in
-  *[\ \	]-Wchar-subscripts[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wchar-subscripts" ;;
-  esac
-
-  case " $CFLAGS " in
-  *[\ \	]-Wmissing-declarations[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wmissing-declarations" ;;
-  esac
-
-  case " $CFLAGS " in
-  *[\ \	]-Wnested-externs[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wnested-externs" ;;
-  esac
-
-  case " $CFLAGS " in
-  *[\ \	]-Wpointer-arith[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wpointer-arith" ;;
-  esac
-
-  case " $CFLAGS " in
-  *[\ \	]-Wcast-align[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wcast-align" ;;
-  esac
-
-  case " $CFLAGS " in
-  *[\ \	]-Wsign-compare[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wsign-compare" ;;
-  esac
 
   if test "x$enable_ansi" = "xyes"; then
     case " $CFLAGS " in

--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,7 @@ echo "
         compiler:                   ${CC}
         cflags:                     ${CFLAGS}
         cppflags:                   ${CPPFLAGS}
+        Warning flags:              ${WARN_CFLAGS}
 
         Accountsservice:            ${enable_accountsservice}
         Application indicator:      ${enable_appindicator}


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum --enable-debug
<cut>

                  polkit-mate 1.23.0
                =======================

        prefix:                     /usr/local
        libdir:                     ${exec_prefix}/lib
        libexecdir:                 ${exec_prefix}/libexec
        bindir:                     ${exec_prefix}/bin
        sbindir:                    ${exec_prefix}/sbin
        datadir:                    ${datarootdir}
        sysconfdir:                 ${prefix}/etc
        localstatedir:              ${prefix}/var

        compiler:                   gcc
        cflags:                      -g -O0
        cppflags:                   
        Warning flags:              -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare

        Accountsservice:            yes
        Application indicator:      yes
        Maintainer mode:            yes

Now type `make' to compile mate-polkit
<cut>
```