### PR TITLE
Fix segfault from gdk_x11_get_server_time if not on X11

### DIFF
--- a/src/polkitmateauthenticator.c
+++ b/src/polkitmateauthenticator.c
@@ -308,8 +308,12 @@ session_request (PolkitAgentSession *session,
     }
 
   gtk_widget_show_all (GTK_WIDGET (authenticator->dialog));
-  gtk_window_present_with_time (GTK_WINDOW (authenticator->dialog),
-                                gdk_x11_get_server_time (gtk_widget_get_window (GTK_WIDGET (authenticator->dialog))));
+  if (GDK_IS_X11_WINDOW (gtk_widget_get_window (GTK_WIDGET (authenticator->dialog))))
+    gtk_window_present_with_time (GTK_WINDOW (authenticator->dialog),
+                                  gdk_x11_get_server_time (gtk_widget_get_window (GTK_WIDGET (authenticator->dialog))));
+  else
+    gtk_window_present (GTK_WINDOW (authenticator->dialog));
+
   password = polkit_mate_authentication_dialog_run_until_response_for_prompt (POLKIT_MATE_AUTHENTICATION_DIALOG (authenticator->dialog),
                                                                                modified_request,
                                                                                echo_on,


### PR DESCRIPTION
This commit will call gtk_window_present_with_time (along with gdk_x11_get_server_time) if on X11, or just gtk_window_present if not to prevent a segmentation fault from occuring