### PR TITLE
build: show configure summary using a pretty format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,24 +163,26 @@ src/Makefile
 AC_OUTPUT
 
 echo "
-                  polkit-mate $VERSION
-                =======================
+Configure summary:
 
-        prefix:                     ${prefix}
-        libdir:                     ${libdir}
-        libexecdir:                 ${libexecdir}
-        bindir:                     ${bindir}
-        sbindir:                    ${sbindir}
-        datadir:                    ${datadir}
-        sysconfdir:                 ${sysconfdir}
-        localstatedir:              ${localstatedir}
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
-        compiler:                   ${CC}
-        cflags:                     ${CFLAGS}
-        cppflags:                   ${CPPFLAGS}
-        Warning flags:              ${WARN_CFLAGS}
+    prefix ...................: ${prefix}
+    libdir ...................: ${libdir}
+    libexecdir ...............: ${libexecdir}
+    bindir ...................: ${bindir}
+    sbindir ..................: ${sbindir}
+    datadir ..................: ${datadir}
+    sysconfdir ...............: ${sysconfdir}
+    localstatedir ............: ${localstatedir}
 
-        Accountsservice:            ${enable_accountsservice}
-        Application indicator:      ${enable_appindicator}
-        Maintainer mode:            ${USE_MAINTAINER_MODE}
+    compiler .................: ${CC}
+    cflags ...................: ${CFLAGS}
+    cppflags .................: ${CPPFLAGS}
+    Warning flags ............: ${WARN_CFLAGS}
+
+    Accountsservice ..........: ${enable_accountsservice}
+    Application indicator ....: ${enable_appindicator}
+    Maintainer mode ..........: ${USE_MAINTAINER_MODE}
 "


### PR DESCRIPTION
sample output:
```
Configure summary:

    polkit-mate 1.26.0
    ==================

    prefix ...................: /usr
    libdir ...................: ${exec_prefix}/lib64
    libexecdir ...............: ${exec_prefix}/libexec
    bindir ...................: ${exec_prefix}/bin
    sbindir ..................: ${exec_prefix}/sbin
    datadir ..................: ${datarootdir}
    sysconfdir ...............: /etc
    localstatedir ............: /var

    compiler .................: gcc
    cflags ...................: 
    cppflags .................: 
    Warning flags ............: -Wall -Wmissing-prototypes

    Accountsservice ..........: yes
    Application indicator ....: yes
    Maintainer mode ..........: yes

Now type `make' to compile mate-polkit
```