### PR TITLE
Fix -Wsign-conversion warning

### DIFF
--- a/src/polkitmateauthenticationdialog.c
+++ b/src/polkitmateauthenticationdialog.c
@@ -650,7 +650,7 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
   GtkWidget *content_area;
   gboolean have_user_combobox;
   gchar *s;
-  guint rows;
+  gint rows;
 
   dialog = POLKIT_MATE_AUTHENTICATION_DIALOG (object);
 
@@ -791,7 +791,7 @@ polkit_mate_authentication_dialog_constructed (GObject *object)
   rows = 0;
   if (dialog->priv->details != NULL)
     {
-      guint n;
+      gint n;
       gchar **keys;
 
       keys = polkit_details_get_keys (dialog->priv->details);

--- a/src/polkitmateauthenticator.c
+++ b/src/polkitmateauthenticator.c
@@ -243,11 +243,14 @@ polkit_mate_authenticator_new (const gchar     *action_id,
   for (l = authenticator->identities, n = 0; l != NULL; l = l->next, n++)
     {
       PolkitUnixUser *user = POLKIT_UNIX_USER (l->data);
-      uid_t uid;
+      gint uid;
       struct passwd *passwd;
 
       uid = polkit_unix_user_get_uid (user);
-      passwd = getpwuid (uid);
+      if (uid == -1)
+        continue;
+
+      passwd = getpwuid ((uid_t) uid);
       authenticator->users[n] = g_strdup (passwd->pw_name);
     }
 


### PR DESCRIPTION
```
polkitmateauthenticator.c:249:13: warning: implicit conversion changes signedness: 'gint' (aka 'int') to 'uid_t' (aka 'unsigned int') [-Wsign-conversion]
      uid = polkit_unix_user_get_uid (user);
          ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
polkitmateauthenticationdialog.c:814:26: warning: implicit conversion changes signedness: 'guint' (aka 'unsigned int') to 'int' [-Wsign-conversion]
          add_row (grid, rows, s, label);
          ~~~~~~~        ^~~~
polkitmateauthenticationdialog.c:835:22: warning: implicit conversion changes signedness: 'guint' (aka 'unsigned int') to 'int' [-Wsign-conversion]
  add_row (grid, rows++, _("<small><b>Action:</b></small>"), label);
  ~~~~~~~        ~~~~^~
polkitmateauthenticationdialog.c:855:22: warning: implicit conversion changes signedness: 'guint' (aka 'unsigned int') to 'int' [-Wsign-conversion]
  add_row (grid, rows++, _("<small><b>Vendor:</b></small>"), label);
  ~~~~~~~        ~~~~^~
```